### PR TITLE
chore: promote jx3-gohttp-3 to version 0.0.2

### DIFF
--- a/config-root/namespaces/jx-staging/jx3-gohttp-3/jx3-gohttp-3-0.0.2-release.yaml
+++ b/config-root/namespaces/jx-staging/jx3-gohttp-3/jx3-gohttp-3-0.0.2-release.yaml
@@ -2,9 +2,9 @@
 apiVersion: jenkins.io/v1
 kind: Release
 metadata:
-  creationTimestamp: "2021-03-12T15:18:16Z"
+  creationTimestamp: "2021-03-12T15:45:06Z"
   deletionTimestamp: null
-  name: 'jx3-gohttp-3-0.0.1'
+  name: 'jx3-gohttp-3-0.0.2'
   namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -18,8 +18,8 @@ spec:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
       message: |
-        chore: release 0.0.1
-      sha: 894596e77736d10381e9cc051bb3658146cd755f
+        chore: release 0.0.2
+      sha: 7a496992cc1935d0a761194bb8f3f85828fc81e6
     - author:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
@@ -29,21 +29,11 @@ spec:
         name: jenkins-x-bot
       message: |
         chore: add variables
-      sha: 68644994b002b365e5b63614f1de17fd05857028
-    - author:
-        email: piontec@gmail.com
-        name: Łukasz Piątkowski
-      branch: master
-      committer:
-        email: piontec@gmail.com
-        name: Łukasz Piątkowski
-      message: |
-        chore: Jenkins X build pack
-      sha: f5928dd6cc8fa2d6ca696e4624d55bb85cd0ec78
+      sha: b18676e18d8291afb3c951757703d77dc10ca90a
   gitHttpUrl: https://github.com/piontec/jx3-gohttp-3
   gitOwner: piontec
   gitRepository: jx3-gohttp-3
   name: 'jx3-gohttp-3'
-  releaseNotesURL: https://github.com/piontec/jx3-gohttp-3/releases/tag/v0.0.1
-  version: v0.0.1
+  releaseNotesURL: https://github.com/piontec/jx3-gohttp-3/releases/tag/v0.0.2
+  version: v0.0.2
 status: {}

--- a/config-root/namespaces/jx-staging/jx3-gohttp-3/jx3-gohttp-3-jx3-gohttp-3-deploy.yaml
+++ b/config-root/namespaces/jx-staging/jx3-gohttp-3/jx3-gohttp-3-jx3-gohttp-3-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: jx3-gohttp-3-jx3-gohttp-3
   labels:
     draft: draft-app
-    chart: "jx3-gohttp-3-0.0.1"
+    chart: "jx3-gohttp-3-0.0.2"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging
   annotations:
@@ -24,11 +24,11 @@ spec:
       serviceAccountName: jx3-gohttp-3-jx3-gohttp-3
       containers:
         - name: jx3-gohttp-3
-          image: "10.106.184.79/piontec/jx3-gohttp-3:0.0.1"
+          image: "10.106.184.79/piontec/jx3-gohttp-3:0.0.2"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 0.0.1
+              value: 0.0.2
           envFrom: null
           ports:
             - name: http

--- a/config-root/namespaces/jx-staging/jx3-gohttp-3/jx3-gohttp-3-svc.yaml
+++ b/config-root/namespaces/jx-staging/jx3-gohttp-3/jx3-gohttp-3-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: jx3-gohttp-3
   labels:
-    chart: "jx3-gohttp-3-0.0.1"
+    chart: "jx3-gohttp-3-0.0.2"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging
 spec:

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -9,7 +9,7 @@ repositories:
   url: http://bucketrepo.jx.svc.cluster.local/bucketrepo/charts/
 releases:
 - chart: dev/jx3-gohttp-3
-  version: 0.0.1
+  version: 0.0.2
   name: jx3-gohttp-3
   values:
   - jx-values.yaml


### PR DESCRIPTION
chore: promote jx3-gohttp-3 to version 0.0.2

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
