### PR TITLE
chore: promote jx3-gohttp-3 to version 0.0.3

### DIFF
--- a/config-root/namespaces/jx-staging/jx3-gohttp-3/jx3-gohttp-3-0.0.3-release.yaml
+++ b/config-root/namespaces/jx-staging/jx3-gohttp-3/jx3-gohttp-3-0.0.3-release.yaml
@@ -2,9 +2,9 @@
 apiVersion: jenkins.io/v1
 kind: Release
 metadata:
-  creationTimestamp: "2021-03-12T15:45:06Z"
+  creationTimestamp: "2021-03-12T18:13:51Z"
   deletionTimestamp: null
-  name: 'jx3-gohttp-3-0.0.2'
+  name: 'jx3-gohttp-3-0.0.3'
   namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -18,8 +18,8 @@ spec:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
       message: |
-        chore: release 0.0.2
-      sha: 7a496992cc1935d0a761194bb8f3f85828fc81e6
+        chore: release 0.0.3
+      sha: 3bb261310625889345424309f3759e99066957bd
     - author:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
@@ -29,11 +29,21 @@ spec:
         name: jenkins-x-bot
       message: |
         chore: add variables
-      sha: b18676e18d8291afb3c951757703d77dc10ca90a
+      sha: c1b88b35be43aad64e6277e49262ae9a73ba5f1b
+    - author:
+        email: piontec@gmail.com
+        name: Łukasz Piątkowski
+      branch: master
+      committer:
+        email: piontec@gmail.com
+        name: Łukasz Piątkowski
+      message: |
+        update code
+      sha: c345151b6b35e0a0c286b856d7f80683fd373ee6
   gitHttpUrl: https://github.com/piontec/jx3-gohttp-3
   gitOwner: piontec
   gitRepository: jx3-gohttp-3
   name: 'jx3-gohttp-3'
-  releaseNotesURL: https://github.com/piontec/jx3-gohttp-3/releases/tag/v0.0.2
-  version: v0.0.2
+  releaseNotesURL: https://github.com/piontec/jx3-gohttp-3/releases/tag/v0.0.3
+  version: v0.0.3
 status: {}

--- a/config-root/namespaces/jx-staging/jx3-gohttp-3/jx3-gohttp-3-jx3-gohttp-3-deploy.yaml
+++ b/config-root/namespaces/jx-staging/jx3-gohttp-3/jx3-gohttp-3-jx3-gohttp-3-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: jx3-gohttp-3-jx3-gohttp-3
   labels:
     draft: draft-app
-    chart: "jx3-gohttp-3-0.0.2"
+    chart: "jx3-gohttp-3-0.0.3"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging
   annotations:
@@ -24,11 +24,11 @@ spec:
       serviceAccountName: jx3-gohttp-3-jx3-gohttp-3
       containers:
         - name: jx3-gohttp-3
-          image: "10.106.184.79/piontec/jx3-gohttp-3:0.0.2"
+          image: "10.106.184.79/piontec/jx3-gohttp-3:0.0.3"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 0.0.2
+              value: 0.0.3
           envFrom: null
           ports:
             - name: http

--- a/config-root/namespaces/jx-staging/jx3-gohttp-3/jx3-gohttp-3-svc.yaml
+++ b/config-root/namespaces/jx-staging/jx3-gohttp-3/jx3-gohttp-3-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: jx3-gohttp-3
   labels:
-    chart: "jx3-gohttp-3-0.0.2"
+    chart: "jx3-gohttp-3-0.0.3"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging
 spec:

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -9,7 +9,7 @@ repositories:
   url: http://bucketrepo.jx.svc.cluster.local/bucketrepo/charts/
 releases:
 - chart: dev/jx3-gohttp-3
-  version: 0.0.2
+  version: 0.0.3
   name: jx3-gohttp-3
   values:
   - jx-values.yaml


### PR DESCRIPTION
chore: promote jx3-gohttp-3 to version 0.0.3

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
