### PR TITLE
chore: promote jx3-gohttp-3 to version 0.0.3

### DIFF
--- a/helmfiles/jx-production/helmfile.yaml
+++ b/helmfiles/jx-production/helmfile.yaml
@@ -9,7 +9,7 @@ repositories:
   url: http://bucketrepo.jx.svc.cluster.local/bucketrepo/charts/
 releases:
 - chart: dev/jx3-gohttp-3
-  version: 0.0.2
+  version: 0.0.3
   name: jx3-gohttp-3
   values:
   - jx-values.yaml


### PR DESCRIPTION
chore: promote jx3-gohttp-3 to version 0.0.3

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
